### PR TITLE
Fix composer version

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -6,12 +6,13 @@ ARG TZ
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /composer
 
+COPY --from=composer:1.10 /usr/bin/composer /usr/bin/composer
+
 RUN apk upgrade --update && \
   apk --no-cache --update add autoconf gcc g++ make icu-dev libzip-dev tzdata && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo ${TZ} > /etc/timezone && \
   docker-php-ext-install intl pdo_mysql mbstring zip bcmath && \
-  curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
   composer config -g repos.packagist composer https://packagist.jp && \
   composer global require hirak/prestissimo
 


### PR DESCRIPTION
https://www.techpit.jp/courses/92/curriculums/95/sections/714/parts/2485/questions/2008

Composer がバージョン2に上がったことで、 `hirak/prestissimo` が見つからない状態になっていました。
ひとまず、Composer 1.10系でタグ指定しました。

```
$ docker-compose up -d

  [InvalidArgumentException]                 
  Could not find package hirak/prestissimo. 
```
